### PR TITLE
Fix the spawning ratio

### DIFF
--- a/2048.c
+++ b/2048.c
@@ -228,7 +228,7 @@ void addRandom(uint16_t board[SIZE][SIZE]) {
 		r = rand()%len;
 		x = list[r][0];
 		y = list[r][1];
-		n = (rand()%2+1)*2;
+		n = ((rand()%10)/9+1)*2;
 		board[x][y]=n;
 	}
 }


### PR DESCRIPTION
The original game spawns a '2' block 90% of the time, while it spawns a '4' block 10% of the time.  Pulling to match this.
