### PR TITLE
Enhance Makefile as Yamakaky suggested

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 CFLAGS += -std=c99
 
-.PHONY: all
+.PHONY: all clean
 
 all: 2048
 


### PR DESCRIPTION
Enhance Makefile to use implicit rule and extends CFLAGS instead of setting it if it doesn't exists.
