### PR TITLE
A dirty solution for issue 26

### DIFF
--- a/2048.c
+++ b/2048.c
@@ -407,17 +407,17 @@ int main(int argc, char *argv[]) {
 			case 106:	// 'j' key
 			case 66:	// down arrow
 				success = moveDown(board);  break;
-			case 12:        // CtrlL
+			case 12:    // CtrlL
 				printf("\033[2J"); // clearing the screen
 				drawBoard(board);
 			default: success = false;
 		}
 		if (success) {
 			// checking if Terminal height and width was changed
-			ioctl(STDOUT_FILENO, TIOCGWINSZ, &TerminalSize_new);
-			if (TerminalSize.ws_row != TerminalSize_new.ws_row || TerminalSize.ws_col != TerminalSize_new.ws_col){
-				printf("\033[2J");
-				TerminalSize = TerminalSize_new;
+		    ioctl(STDOUT_FILENO, TIOCGWINSZ, &TerminalSize_new);
+		    if (TerminalSize.ws_row != TerminalSize_new.ws_row || TerminalSize.ws_col != TerminalSize_new.ws_col){
+			    printf("\033[2J");
+			    TerminalSize = TerminalSize_new;
 			}
 			drawBoard(board);
 			usleep(150000);

--- a/2048.c
+++ b/2048.c
@@ -358,10 +358,6 @@ void signal_callback_handler(int signum) {
 	exit(signum);
 }
 
-void clear_screen(){
-	system("clear"); // TODO: find a cleaner way!
-}
-
 int main(int argc, char *argv[]) {
 	uint8_t board[SIZE][SIZE];
 	char c;
@@ -412,7 +408,7 @@ int main(int argc, char *argv[]) {
 			case 66:	// down arrow
 				success = moveDown(board);  break;
 			case 12:        // CtrlL
-				clear_screen();
+				printf("\033[2J"); // clearing the screen
 				drawBoard(board);
 			default: success = false;
 		}

--- a/2048.c
+++ b/2048.c
@@ -416,7 +416,7 @@ int main(int argc, char *argv[]) {
 			// checking if Terminal height as width was changed
 			ioctl(STDOUT_FILENO, TIOCGWINSZ, &TerminalSize_new);
 			if (TerminalSize.ws_row != TerminalSize_new.ws_row || TerminalSize.ws_col != TerminalSize_new.ws_col){
-				clear_screen();
+				print("\033[2J");
 				TerminalSize = TerminalSize_new;
 			}
 			drawBoard(board);

--- a/2048.c
+++ b/2048.c
@@ -419,7 +419,7 @@ int main(int argc, char *argv[]) {
 		if (success) {
 			// checking if Terminal height as width was changed
 			ioctl(STDOUT_FILENO, TIOCGWINSZ, &TerminalSize_new);
-			if (TerminalSize.ws_row != TerminalSize_new.ws_row || TerminalSize.ws_row != TerminalSize_new.ws_col){
+			if (TerminalSize.ws_row != TerminalSize_new.ws_row || TerminalSize.ws_col != TerminalSize_new.ws_col){
 				clear_screen();
 				TerminalSize = TerminalSize_new;
 			}

--- a/2048.c
+++ b/2048.c
@@ -413,7 +413,7 @@ int main(int argc, char *argv[]) {
 			default: success = false;
 		}
 		if (success) {
-			// checking if Terminal height as width was changed
+			// checking if Terminal height and width was changed
 			ioctl(STDOUT_FILENO, TIOCGWINSZ, &TerminalSize_new);
 			if (TerminalSize.ws_row != TerminalSize_new.ws_row || TerminalSize.ws_col != TerminalSize_new.ws_col){
 				printf("\033[2J");

--- a/2048.c
+++ b/2048.c
@@ -16,6 +16,7 @@
 #include <stdint.h>
 #include <time.h>
 #include <signal.h>
+#include <sys/ioctl.h> // Is this standard?
 
 #define SIZE 4
 uint32_t score=0;
@@ -357,6 +358,10 @@ void signal_callback_handler(int signum) {
 	exit(signum);
 }
 
+void clear_screen(){
+	system("clear"); // TODO: find a cleaner way!
+}
+
 int main(int argc, char *argv[]) {
 	uint8_t board[SIZE][SIZE];
 	char c;
@@ -379,6 +384,10 @@ int main(int argc, char *argv[]) {
 
 	initBoard(board);
 	setBufferedInput(false);
+	
+	struct winsize TerminalSize, TerminalSize_new;
+	ioctl(STDOUT_FILENO, TIOCGWINSZ, &TerminalSize);
+	
 	while (true) {
 		c=getchar();
 		if (c == -1){ //TODO: maybe replace this -1 with a pre-defined constant(if it's in one of header files)
@@ -402,9 +411,18 @@ int main(int argc, char *argv[]) {
 			case 106:	// 'j' key
 			case 66:	// down arrow
 				success = moveDown(board);  break;
+			case 12:        // CtrlL
+				clear_screen();
+				drawBoard(board);
 			default: success = false;
 		}
 		if (success) {
+			// checking if Terminal height as width was changed
+			ioctl(STDOUT_FILENO, TIOCGWINSZ, &TerminalSize_new);
+			if (TerminalSize.ws_row != TerminalSize_new.ws_row || TerminalSize.ws_row != TerminalSize_new.ws_col){
+				clear_screen();
+				TerminalSize = TerminalSize_new;
+			}
 			drawBoard(board);
 			usleep(150000);
 			addRandom(board);

--- a/2048.c
+++ b/2048.c
@@ -416,7 +416,7 @@ int main(int argc, char *argv[]) {
 			// checking if Terminal height as width was changed
 			ioctl(STDOUT_FILENO, TIOCGWINSZ, &TerminalSize_new);
 			if (TerminalSize.ws_row != TerminalSize_new.ws_row || TerminalSize.ws_col != TerminalSize_new.ws_col){
-				print("\033[2J");
+				printf("\033[2J");
 				TerminalSize = TerminalSize_new;
 			}
 			drawBoard(board);


### PR DESCRIPTION
Issue #26 has been fixed in a dirty way: I used `ioctl.h` which I don't how much standard is and also system("clear") to clear the screen. However worked on my PC which is Linux and also a remote OpenBSD. But this way is dirty, I have warned you!
P.S.: Also CtrlL does redraw.
Credit(s): https://stackoverflow.com/questions/1022957/getting-terminal-width-in-c
  