### PR TITLE
add: link to replit run

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "bash"
+run = "gcc ./2048.c -o out && chmod +x out && ./out"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 2048.c
 ======
 
+[![run on repl.it](http://repl.it/badge/github/mevdschee/2048.c)](https://repl.it/github/mevdschee/2048.c)
+
 [Spanish](README_es.md)
 
 ![screenshot](screenshot.png)


### PR DESCRIPTION
i think it would be pretty cool to let people see how this code works (and edit / preview the program) right in their browser, without any manual downloads or installation. i'm thinking we can add a 'run on repl.it' button, which redirects to something like [this](https://repl.it/@eankeen/run-2048.c):

![image](https://i.imgur.com/U804s1L.png)
