### PR TITLE
Change path for binary to match `Makefile`

### DIFF
--- a/2048.desktop
+++ b/2048.desktop
@@ -2,7 +2,7 @@
 Name=2048
 Comment=Add values sliding tiles until you reach 2048
 Comment[es]=Alcanza el 2048 deslizando y sumando teselas
-Exec=sh -c '/usr/games/2048;echo;echo PRESS ENTER TO EXIT;read line'
+Exec=sh -c '/usr/bin/2048;echo;echo PRESS ENTER TO EXIT;read line'
 Icon=2048
 Terminal=true
 Type=Application


### PR DESCRIPTION
`2048.desktop` has `usr/games` as the path to the 2048 binary.
The Makefile has `usr/bin` as the install path.

Since `usr/games` isn't really the right use case for a single binary, I propose changing the desktop to `usr/bin`