### PR TITLE
Enabled program to run on MacOS + changed Installation command

### DIFF
--- a/2048.c
+++ b/2048.c
@@ -6,6 +6,10 @@
  ============================================================================
  */
 
+#ifdef __APPLE__
+   #define _DARWIN_C_SOURCE
+#endif
+
 #define _XOPEN_SOURCE 500
 #include <stdio.h>
 #include <stdlib.h>

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Tested on: GNU/Linux, FreeBSD, OpenBSD
 
 ```
 wget https://raw.githubusercontent.com/mevdschee/2048.c/master/2048.c
-gcc -o 2048 2048.c
+cc -o 2048 2048.c
 ./2048
 ```
 


### PR DESCRIPTION
Apple is funny about using snprintf, as described in issue https://github.com/mevdschee/2048.c/issues/45.

I also updated the README.md to specify using 'cc' instead of strictly 'gcc'.

cc is a symlink to the chosen compiler (by default, Linux points to gcc), but it is not guaranteed that gcc is installed on the users system (for example, it is not on OpenBSD).