### PR TITLE
In README, mention apt install

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ Tested on: GNU/Linux, FreeBSD, OpenBSD
 
 ### Installation
 
+#### On Debian, Ubuntu derivatives
+Install from package manager: `sudo apt install 2048`
+
+#### Source Installation
 ```
 wget https://raw.githubusercontent.com/mevdschee/2048.c/master/2048.c
 gcc -o 2048 2048.c


### PR DESCRIPTION
This program can also be installed using `apt install 2048` can be done in Debian derivatives. Mention this in README.