### PR TITLE
src: apply some fixes

### DIFF
--- a/2048.c
+++ b/2048.c
@@ -47,7 +47,7 @@ void drawBoard(uint8_t board[SIZE][SIZE], uint8_t scheme, uint32_t score)
 {
 	uint8_t x, y, fg, bg;
 	printf("\033[H"); // move cursor to 0,0
-	printf("2048.c %17d pts\n\n", score);
+	printf("2048.c %17u pts\n\n", score);
 	for (y = 0; y < SIZE; y++)
 	{
 		for (x = 0; x < SIZE; x++)
@@ -164,7 +164,7 @@ void rotateBoard(uint8_t board[SIZE][SIZE])
 	uint8_t tmp;
 	for (i = 0; i < n / 2; i++)
 	{
-		for (j = i; j < n - i - 1; j++)
+		for (j = i; j < (uint8_t)(n - i - 1); j++)
 		{
 			tmp = board[i][j];
 			board[i][j] = board[j][n - i - 1];
@@ -404,7 +404,7 @@ int test()
 			{
 				printf("%d ", array[i]);
 			}
-			printf("(%d points) expected ", score);
+			printf("(%u points) expected ", score);
 			for (i = 0; i < SIZE; i++)
 			{
 				printf("%d ", in[i]);
@@ -439,7 +439,7 @@ int main(int argc, char *argv[])
 	uint8_t board[SIZE][SIZE];
 	uint8_t scheme = 0;
 	uint32_t score = 0;
-	char c;
+	int c;
 	bool success;
 
 	if (argc == 2 && strcmp(argv[1], "test") == 0)
@@ -467,7 +467,7 @@ int main(int argc, char *argv[])
 	while (true)
 	{
 		c = getchar();
-		if (c == -1)
+		if (c == EOF)
 		{
 			puts("\nError! Cannot read keyboard input!");
 			break;


### PR DESCRIPTION
- Use the `%u` format specifier for printing `uint32_t`.
- Cast the right-hand side of the condition of the `for` loop to `uint8_t` where it was implicitly promoted to `int`.
- Use `int` variable for `getchar()` since it can return `EOF` (`-1`) to indicate an error, `char` cannot hold negative integers.
- Use `EOF` instead of `-1` to be idiomatic.