### PR TITLE
Add --help, --version, error on invalid CLI arguments

### DIFF
--- a/2048.c
+++ b/2048.c
@@ -447,11 +447,11 @@ struct CliOption
     char* description;
 };
 struct CliOption cli_options[] = {
-    {"--help", "Show this help message"},
-    {"--version", "Show version number"},
-    {"blackwhite", "Use black and white colors"},
-    {"bluered", "Use blue and red colors"},
-    {"test", "Run the test suite"},
+    {"--help", "Show this help message."},
+    {"--version", "Show version number."},
+    {"bluered", "Use a blue-to-red color scheme (requires 256-color terminal support). If unsupported, it will fall back to black-to-white."},
+    {"blackwhite", "The default color scheme is black-to-white (requires 256-color terminal support)."},
+    {"test", "Run the test suite."},
 };
 
 char* parseArgs(int argc, char* argv[], int* status_code)

--- a/2048.c
+++ b/2048.c
@@ -18,6 +18,7 @@
 #include <signal.h>	  // defines: signal, SIGINT
 
 #define SIZE 4
+#define VERSION "1.0"
 
 // this function receives 2 pointers (indicated by *) so it can set their values
 void getColors(uint8_t value, uint8_t scheme, uint8_t *foreground, uint8_t *background)
@@ -425,6 +426,12 @@ int test()
 	return !success;
 }
 
+int version()
+{
+    printf("2048.c version %s\n", VERSION);
+    return EXIT_SUCCESS;
+}
+
 void signal_callback_handler(int signum)
 {
 	printf("         TERMINATED         \n");
@@ -432,6 +439,48 @@ void signal_callback_handler(int signum)
 	// make cursor visible, reset all modes
 	printf("\033[?25h\033[m");
 	exit(signum);
+}
+
+struct CliOption
+{
+    char* name;
+    char* description;
+};
+struct CliOption cli_options[] = {
+    {"--help", "Show this help message"},
+    {"--version", "Show version number"},
+    {"blackwhite", "Use black and white colors"},
+    {"bluered", "Use blue and red colors"},
+    {"test", "Run the test suite"},
+};
+
+char* parseArgs(int argc, char* argv[], int* status_code)
+{
+    if (argc == 1)
+    {
+        return "blackwhite";      // default color scheme
+    }
+    else if (argc == 2)
+    {
+        return argv[1];
+    }
+    else
+    {
+        printf("Invalid number of arguments\n");
+        *status_code = EXIT_FAILURE;
+        return "--help";
+    }
+}
+
+int help(int success) {
+    printf("Usage: 2048 [OPTION]\n");
+    printf("Play the game 2048 in the console\n\n");
+    printf("Options:\n");
+    for (int i = 0; i < sizeof(cli_options) / sizeof(cli_options[0]); i++)
+    {
+        printf("  %-12s %s\n", cli_options[i].name, cli_options[i].description);
+    }
+    return success;
 }
 
 int main(int argc, char *argv[])
@@ -442,18 +491,31 @@ int main(int argc, char *argv[])
 	char c;
 	bool success;
 
-	if (argc == 2 && strcmp(argv[1], "test") == 0)
+    int status_code = EXIT_SUCCESS;
+    char* option = parseArgs(argc, argv, &status_code);
+    if (strcmp(option, "--help") == 0 || strcmp(option, "-h") == 0)
+    {
+        return help(status_code);
+    }
+    else if (strcmp(option, "--version") == 0 || strcmp(option, "-v") == 0)
+    {
+        return version();
+    }
+	else if (strcmp(option, "test") == 0)
 	{
 		return test();
 	}
-	if (argc == 2 && strcmp(argv[1], "blackwhite") == 0)
+	else if (strcmp(option, "blackwhite") == 0)
 	{
 		scheme = 1;
 	}
-	if (argc == 2 && strcmp(argv[1], "bluered") == 0)
+	else if (strcmp(option, "bluered") == 0)
 	{
 		scheme = 2;
-	}
+	} else {
+        printf("Invalid option: %s\n", option);
+        return help(EXIT_FAILURE);
+    }
 
 	// make cursor invisible, erase entire screen
 	printf("\033[?25l\033[2J");

--- a/README.md
+++ b/README.md
@@ -52,6 +52,12 @@ For the blue-to-red color scheme (requires 256 colors):
 ./2048 bluered
 ```
 
+Show help message (shows all supported CLI options):
+
+```
+./2048 help
+```
+
 ### Contributing
 
 Contributions are very welcome. Always run the tests before committing using:


### PR DESCRIPTION
Show help message (all supported arguments):
```console
$ 2048 --help           # alternatively: 2048 -h
Usage: 2048 [OPTION]
Play the game 2048 in the console

Options:
  --help       Show this help message.
  --version    Show version number.
  bluered      Use a blue-to-red color scheme (requires 256-color terminal support). If unsupported, it will fall back to black-to-white.
  blackwhite   The default color scheme is black-to-white (requires 256-color terminal support).
  test         Run the test suite.
```

Show version:
```console
$ 2048 --version      # alternatively: 2048 -v
2048.c version 1.0
```

Handle invalid CLI arguments:
```console
$ ./2048 some invalid arguments
Invalid number of arguments
Usage: 2048 [OPTION]
Play the game 2048 in the console

Options:
  --help       Show this help message.
  --version    Show version number.
  bluered      Use a blue-to-red color scheme (requires 256-color terminal support). If unsupported, it will fall back to black-to-white.
  blackwhite   The default color scheme is black-to-white (requires 256-color terminal support).
  test         Run the test suite.
$ echo $?
1
```

Verified that all tests are passing:
```console
$ 2048 test
All 13 tests executed successfully
```

Fixes Issue #56